### PR TITLE
append scikit-sparse to Sparse linear solvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ them.
   (Python, MIT, GitHub)
 - [PyAMG](https://pyamg.github.io) - Algebraic Multigrid Solvers in Python.
   (Python, MIT, [GitHub](https://github.com/pyamg/pyamg))
-- [scikit-sparse](https://github.com/scikit-sparse/scikit-sparse) - Sparse Cholesky decomposition in SciPy (Python, [BSD 2-Clause "Simplified"](https://github.com/scikit-sparse/scikit-sparse/blob/master/LICENSE.txt), GitHub)
+- [scikit-sparse](https://github.com/scikit-sparse/scikit-sparse) - Sparse Cholesky decomposition in SciPy. (Python, [BSD 2-Clause "Simplified"](https://github.com/scikit-sparse/scikit-sparse/blob/master/LICENSE.txt), GitHub)
 
 ## Other libraries and tools
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ them.
   (Python, MIT, GitHub)
 - [PyAMG](https://pyamg.github.io) - Algebraic Multigrid Solvers in Python.
   (Python, MIT, [GitHub](https://github.com/pyamg/pyamg))
-- [scikit-sparse](https://github.com/scikit-sparse/scikit-sparse) - Sparse Cholesky decomposition in SciPy. (Python, [BSD 2-Clause "Simplified"](https://github.com/scikit-sparse/scikit-sparse/blob/master/LICENSE.txt), GitHub)
+- [scikit-sparse](https://github.com/scikit-sparse/scikit-sparse) - Sparse Cholesky decomposition in SciPy.
+  (Python, [BSD 2-Clause "Simplified"](https://github.com/scikit-sparse/scikit-sparse/blob/master/LICENSE.txt), GitHub)
 
 ## Other libraries and tools
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ them.
   (Python, MIT, GitHub)
 - [PyAMG](https://pyamg.github.io) - Algebraic Multigrid Solvers in Python.
   (Python, MIT, [GitHub](https://github.com/pyamg/pyamg))
-- [scikit-sparse](https://github.com/scikit-sparse/scikit-sparse) - Wraps CHOLMOD for sparse Cholesky decomposition in SciPy (Python, [BSD 2-Clause "Simplified"](https://github.com/scikit-sparse/scikit-sparse/blob/master/LICENSE.txt), GitHub)
+- [scikit-sparse](https://github.com/scikit-sparse/scikit-sparse) - Sparse Cholesky decomposition in SciPy (Python, [BSD 2-Clause "Simplified"](https://github.com/scikit-sparse/scikit-sparse/blob/master/LICENSE.txt), GitHub)
 
 ## Other libraries and tools
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ them.
   (Python, MIT, GitHub)
 - [PyAMG](https://pyamg.github.io) - Algebraic Multigrid Solvers in Python.
   (Python, MIT, [GitHub](https://github.com/pyamg/pyamg))
-
+- [scikit-sparse](https://github.com/scikit-sparse/scikit-sparse) - Wraps CHOLMOD for sparse Cholesky decomposition in SciPy (Python, [BSD 2-Clause "Simplified"](https://github.com/scikit-sparse/scikit-sparse/blob/master/LICENSE.txt), GitHub)
 
 ## Other libraries and tools
 


### PR DESCRIPTION
Sparse Cholesky factorization is _awesome_ for fast timestepping in linear time-invariant parabolic problems like the heat equation with constant time-stepping.  scikit-sparse makes it available for SciPy.  It's not in SciPy because of the licence on the underlying CHOLMOD (too copyleft or something, dunno, ask a lawyer).