### PR TITLE
Add SeismicMesh

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ them.
   (C++, MPL 2, [GitHub](https://github.com/wildmeshing/TriWild))
 - [fTetWild](https://arxiv.org/abs/1908.03581) - Fast Tetrahedral Meshing in the Wild.
   (C++, MPL 2, [GitHub](https://github.com/wildmeshing/fTetWild))
-
+- [SeismicMesh](https://github.com/krober10nd/SeismicMesh) - Parallel 2D/3D triangle/tetrahedral mesh generation with sliver removal.
+   (Python and C++, GPL 3, GitHub)
 ## Sparse linear solvers
 
 - [SuperLU](https://portal.nersc.gov/project/sparse/superlu/) - Direct solution of large, sparse, nonsymmetric systems of linear equations.


### PR DESCRIPTION
SeismicMesh is *pretty cool* for parallel 2D/3D mesh generation in Python and represents a general purpose mesh generator that is competitive with CGAL and Gmsh as was established in the JOSS [article](https://joss.theoj.org/papers/10.21105/joss.02687). It also is the only open source implementation of parallel DistMesh on the web that, at the very least, is well-documented.

Also, Antoine wants to know if you still go to "Süss War Gestern" :]
