### PR TITLE
Add DEVSIM

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ them.
   (C, 2-clause BSD, [GitHub](https://github.com/CEED/libCEED))
 - [scikit-fem](https://github.com/kinnala/scikit-fem) - Simple finite element assemblers.
   (Python, BSD/GPL, GitHub)
-- [DEVSIM](https://devsim.org/index.html) - Finite-volume solver with symbolic models (C++/Python, Apache, [Github](https://github.com/devsim/devsim))
+- [DEVSIM](https://devsim.org/index.html) - Finite-volume solver with symbolic models (C++/Python, Apache 2.0, [Github](https://github.com/devsim/devsim))
 
 ## Meshing
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ them.
   (C, 2-clause BSD, [GitHub](https://github.com/CEED/libCEED))
 - [scikit-fem](https://github.com/kinnala/scikit-fem) - Simple finite element assemblers.
   (Python, BSD/GPL, GitHub)
+- [DEVSIM](https://devsim.org/index.html) - Finite-volume solver with symbolic models (C++/Python, Apache, [Github](https://github.com/devsim/devsim))
 
 ## Meshing
 


### PR DESCRIPTION
I'd like to nominate [DEVSIM](https://devsim.org/introduction.html) to add to the finite element section, since as of their 2.3.1 release (just last week!) they are on Pypi (https://pypi.org/project/devsim/).

The code is under an Apache 2.0 license, and while it was coded with TCAD semiconductor modeling in mind, it is quite generic, since the PDEs being solved are defined via human-readable strings through a Python interface.

There is an active community on [the official repo](https://github.com/devsim/devsim) and [forums](https://forum.devsim.org/), and the creator Juan Sanchez (@tcaduser) is quite active on both platforms. It has also been the subject of many [publications](https://devsim.org/introduction.html#publications).