### PR TITLE
Add GetFEM to the Finite Elements list

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ them.
   (C, 2-clause BSD, [GitHub](https://github.com/CEED/libCEED))
 - [scikit-fem](https://github.com/kinnala/scikit-fem) - Simple finite element assemblers.
   (Python, BSD/GPL, GitHub)
+- [GetFEM](https://getfem.org) - Framework for solving systems of coupled nonlinear PDEs with the finite element method.
+  (C++/Python/Octave/Matlab, LGPL 3, [Savannah](https://git.savannah.nongnu.org/cgit/getfem.git/))
 
 ## Meshing
 


### PR DESCRIPTION
GetFEM is similar to FEniCS, Firedrake and FreeFEM, already in the list, but it has its own strengths:
 - Good support for modelling of contact problems
 - C++ API, as well as support for several scripting languages Python/Octave/Matlab
 - A weak form language which is isolated from the programming language
 - Support for XFEM and for working with non-matching meshes in general

GetFEM is easy to try out, but also suitable for creating large models:
 - is available on Debian/Ubuntu/Docker
 - has large collection of examples
 - imports meshes created with gmsh, gid or ANSYS
 - supports parallel distributed assemblies with OpenMPI
 - it is one of the oldest public FE codes (over 20 years as open source), but it has been continuously maintained and modernized
 