### PR TITLE
Add Prizm, a tool for debugging computational geometry, to the Visualization section

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ them.
 - [TTK](https://topology-tool-kit.github.io/) - Topological data analysis and visualization.
   (C++/Python, BSD, [GitHub](https://github.com/topology-tool-kit/ttk))
 - [morphologica](https://github.com/ABRG-Models/morphologica) - Header-only, modern OpenGL code to visualize numerical simulations at runtime. (C++, Apache 2.0, GitHub)
+- [Prizm](https://github.com/okmatija/Prizm/) - Computational geometry debugging tool. (Jai/C++, MIT, [GitHub](https://github.com/okmatija/Prizm/))
 
 ## Other libraries and tools
 


### PR DESCRIPTION
Prizm is a tool for debugging computational geometry. A brief summary of features:

* Load .obj geometry from files or folders, with an option to monitor and hot-reload changes.
* Find and visualize bugs in awkwardly shaped meshes or amongst multiple meshes using a UI that helps you work fast.
* Attach text annotations to various geometric elements and view them within Prizm.
* Use console commands to process loaded geometry to help you tackle more complicated bugs.
* Use an API, configured and accessed via the UI, to log .obj files from anywhere in your program.
* The API supports working with the Unreal geometry library and I am planning similar support for other tools/libraries.
* Prizm runs Linux and Windows and is distributed under the MIT license.
* In development for ~4 years, the feature set has grown (and shrunk!) according to what proved useful in practice

See the Prizm GItHub [wiki](https://github.com/okmatija/Prizm/wiki) for short tutorial videos (1-2.5mins) covering the main features. The GitHub [README](https://github.com/okmatija/Prizm/) has a description of how Prizm is differentiated from similar tools (and hence, why I think it would be a useful addition to the awesome-scientific-computing list), if you like I can paraphrase this in this PR