### PR TITLE
Add MFC: exascale multiphase flow solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ them.
   [GitHub](https://github.com/qhull/qhull/))
 - [GSL](https://www.gnu.org/software/gsl/) - Random number generators, special functions, and least-squares fitting etc.
   (C/C++, GPL 3, [Savannah](https://savannah.gnu.org/projects/gsl))
+- [MFC](https://mflowcode.github.io/) - Exascale multiphase compressible flow solver; 2025 Gordon Bell Prize Finalist.
+  (Fortran, MIT, [GitHub](https://github.com/MFlowCode/MFC))
 - [OpenFOAM](https://www.openfoam.com) - Free, open source CFD (computational fluid dynamics) software.
   (C++, GPL 3, [GitHub](https://github.com/OpenFOAM/OpenFOAM-dev))
 - [quadpy](https://github.com/sigma-py/quadpy) - Numerical integration (quadrature, cubature) in Python.


### PR DESCRIPTION
Adds [MFC](https://github.com/MFlowCode/MFC) to the "Other libraries and tools" section alongside OpenFOAM.

MFC is an exascale multiphase compressible flow solver written in Fortran with Fypp metaprogramming. It was a 2025 Gordon Bell Prize Finalist and conducted the largest known public CFD simulation at 200 trillion grid points. It scales ideally to >43K GPUs on leadership-class supercomputers (OLCF Frontier, LLNL El Capitan). MIT licensed and actively maintained.

- Website: https://mflowcode.github.io/
- Paper: https://doi.org/10.1016/j.cpc.2026.110055