### PR TITLE
Add MetaReview - meta-analysis platform for medical research

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ them.
   (Python, MIT, GitHub)
 - [HPDDM](https://github.com/hpddm/hpddm) - High-performance unified framework for domain decomposition methods.
   (C++, LGPL 3, GitHub)
+- [MetaReview](https://metareview-8c1.pages.dev/) - Free online meta-analysis platform with forest plots, funnel plots, and statistical diagnostics for evidence-based medicine.
+  (JavaScript/TypeScript, MIT, [GitHub](https://github.com/TerryFYL/metareview))
 
 ## Community
 


### PR DESCRIPTION
Add [MetaReview](https://metareview-8c1.pages.dev/) to the Other libraries and tools section.

MetaReview is a free, open-source meta-analysis platform for evidence-based medicine, featuring:
- Statistical computation: OR, RR, HR, MD, SMD effect sizes with fixed/random effects models
- Visualizations: Forest plots, funnel plots, Galbraith plots, L'Abbé plots, Baujat plots
- Diagnostics: I²/Q heterogeneity, Egger's/Begg's publication bias, trim-and-fill, meta-regression
- Built with React + TypeScript + Vite + D3.js, deployed on Cloudflare Pages

**GitHub:** https://github.com/TerryFYL/metareview
**Live:** https://metareview-8c1.pages.dev/