### PR TITLE
Add awesome-ai-cae to Related lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,7 @@ them.
 - [NA Digest](https://netlib.org/na-digest-html/) - Collection of articles on topics related to numerical analysis and those who practice it.
 - [Gabriel Peyré on Bluesky](https://bsky.app/profile/gabrielpeyre.bsky.social) - One post a day on computational mathematics.
 - [Discord: Numerical Software](https://discord.com/invite/hnTJ5MRX2Y) - Discord messaging server on numerical software.
+
+## Related lists
+
+- [Awesome AI-CAE](https://github.com/kimimgo/awesome-ai-cae) - AI-ready tools for Computer-Aided Engineering with MCP servers, Python APIs, and ML frameworks for simulation automation.


### PR DESCRIPTION
This PR adds [awesome-ai-cae](https://github.com/kimimgo/awesome-ai-cae) as a related awesome list in a new "Related lists" section.

**awesome-ai-cae** is a curated list of 104 AI-ready tools for Computer-Aided Engineering (CAE), covering:

- MCP servers for simulation automation (OpenFOAM, ParaView)
- Neural operators and PINNs (DeepXDE, FNO, PhiFlow)
- Differentiable simulation frameworks (Taichi, JAX-CFD, Warp)
- AI/ML-accelerated CFD, FEA, SPH, and mesh generation
- Core Engine Readiness assessment for 13 foundational solvers

It complements awesome-scientific-computing by focusing specifically on the intersection of **AI agents and engineering simulation** — tools that are programmable via Python API, CLI, or Model Context Protocol (MCP).

Many tools in awesome-scientific-computing (FEniCS, Gmsh, OpenFOAM, ParaView, meshio, PyDMD) are also assessed for AI-readiness in awesome-ai-cae.